### PR TITLE
Use contract to track notifications

### DIFF
--- a/lib/contracts/hubot-notification.ts
+++ b/lib/contracts/hubot-notification.ts
@@ -1,0 +1,29 @@
+import type { ContractDefinition } from 'autumndb';
+
+export const hubotNotification: ContractDefinition = {
+	slug: 'hubot-notification',
+	type: 'type@1.0.0',
+	name: 'Hubot notification',
+	markers: [],
+	data: {
+		schema: {
+			type: 'object',
+			required: ['data'],
+			properties: {
+				data: {
+					type: 'object',
+					required: ['event'],
+					properties: {
+						event: {
+							type: 'string',
+						},
+						type: {
+							type: 'string',
+						},
+					},
+				},
+			},
+		},
+		indexed_fields: [['data.event'], ['data.type']],
+	},
+};

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -1,4 +1,5 @@
 import type { ContractDefinition } from 'autumndb';
+import { hubotNotification } from './hubot-notification';
 import { triggeredActionHubotBrainstormHashtags } from './triggered-action-hubot-brainstorm-hashtags';
 import { triggeredActionHubotEcho } from './triggered-action-hubot-echo';
 import { triggeredActionHubotEmailHashtags } from './triggered-action-hubot-email-hashtags';
@@ -14,6 +15,7 @@ import { triggeredActionHubotTimezone } from './triggered-action-hubot-timezone'
 import { triggeredActionHubotThreadWidePing } from './triggered-action-hubot-thread-wide-ping';
 
 export const contracts: ContractDefinition[] = [
+	hubotNotification,
 	triggeredActionHubotBrainstormHashtags,
 	triggeredActionHubotEcho,
 	triggeredActionHubotEmailHashtags,

--- a/test/integration/actions/action-hubot-support-notify.spec.ts
+++ b/test/integration/actions/action-hubot-support-notify.spec.ts
@@ -88,6 +88,7 @@ test('Should send support handover message', async () => {
 			kind: 'calendar#events',
 			items: ['foo', 'bar', 'buz', 'baz'].map((name) => {
 				return {
+					id: aTestUtils.generateRandomId(),
 					summary: `${name} on support`,
 					start: {
 						dateTime:


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@monarci.com>

---

Using an in-memory cache to track support/event notifications will cause issues after instance restarts if an event that has already been notified still matches the criteria to be notified. Using persistent data storage allows us to track past notifications across restarts.